### PR TITLE
Fix missing submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "1.1.pricing"]
+	path = 1.1.pricing
+	url = https://github.com/phanthaiduong22/gemo-technical1-pricing


### PR DESCRIPTION
I fixed your submodule URL for `1.1.pricing` so that your repo can be cloned correctly with submodules.

**Before:**

```
❯ git submodule update --init --recursive
fatal: No url found for submodule path '1.1.pricing' in .gitmodules
```

**After:**

```
git submodule update --init --recursive
Submodule '1.1.pricing' (https://github.com/phanthaiduong22/gemo-technical1-pricing) registered for path '1.1.pricing'
Cloning into '/Users/.../Works/gemo-thaiduong/1.1.pricing'...
Submodule path '1.1.pricing': checked out '9f165a9f0860973853c369eba2a0eec7ec4a8859'
```